### PR TITLE
QS-17: Tag stem dedup v1.0 + soft-fail integration

### DIFF
--- a/functions/__tests__/tagUtils.dedup.test.js
+++ b/functions/__tests__/tagUtils.dedup.test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const { toStemKey, dedupeByStem, _stemWord } = require('../utils/tagUtils');
+
+describe('tag stem dedup v1.0', () => {
+  test('word stemming basics', () => {
+    expect(_stemWord("dogs")).toBe("dog");
+    expect(_stemWord("boxes")).toBe("box");
+    expect(_stemWord("puppies")).toBe("puppy");
+  });
+
+  test('phrase key normalization', () => {
+    expect(toStemKey("Silver Rings")).toBe("silver-ring");
+    expect(toStemKey("silver ring")).toBe("silver-ring");
+    expect(toStemKey("silver-ring")).toBe("silver-ring");
+  });
+
+  test('dedupe preserves first occurrence and drops later variants', () => {
+    const tags = ["dog", "dogs", "puppy", "puppies", "silver ring", "silver rings", "cat"];
+    const { unique, dropped } = dedupeByStem(tags);
+    expect(unique).toEqual(["dog", "puppy", "silver ring", "cat"]);
+    expect(dropped).toEqual(["dogs", "puppies", "silver rings"]);
+  });
+
+  test('handles non-ascii and punctuation gracefully', () => {
+    const tags = ["café ring", "cafe rings"];
+    const { unique, dropped } = dedupeByStem(tags);
+    expect(unique[0]).toBe("café ring");
+    expect(dropped).toEqual(["cafe rings"]);
+  });
+});

--- a/functions/utils/tagUtils.js
+++ b/functions/utils/tagUtils.js
@@ -1,22 +1,59 @@
 // functions/utils/tagUtils.js
 
 /**
- * Deduplicate tags based on a simple stem (lowercase, non-alphanumeric removed, optional trailing "s" stripped).
- * @param {string[]} tags - original tags array
- * @returns {string[]} deduplicated tags (order preserved, first occurrence kept)
+ * Tag stem dedup v1.0 — lichtgewicht, dependency-free
+ * Doel: tags met zelfde betekenis (enkelvoud/meervoud/varianten) tot één reduceren.
  */
-function dedupeTagsByStem(tags = []) {
-  const seen = new Set();
-  const out = [];
-  const stem = (str) => str.toLowerCase().replace(/[^a-z0-9]+/g, '').replace(/s$/, '');
-  for (const tag of tags) {
-    const key = stem(tag);
-    if (!seen.has(key)) {
-      seen.add(key);
-      out.push(tag);
-    }
-  }
-  return out;
+
+'use strict';
+
+function asciiLower(s) {
+  if (!s) return '';
+  return String(s)
+    .normalize('NFD').replace(/[\u0300-\u036f]/g, '') // strip diacritics
+    .toLowerCase();
 }
 
-module.exports = { dedupeTagsByStem };
+// Zeer eenvoudige stemmer (bewust conservatief, fail-safe)
+function stemWord(w) {
+  let x = w;
+  x = x.replace(/^(.+)'s$/, '$1');       // dog's -> dog
+  if (x.endsWith('ies') && x.length > 3) x = x.slice(0, -3) + 'y';   // puppies -> puppy
+  else if (x.endsWith('sses')) x = x.slice(0, -2);                   // classes -> class
+  else if (x.endsWith('es') && x.length > 3) x = x.slice(0, -2);     // boxes -> box
+  else if (x.endsWith('s') && x.length > 3) x = x.slice(0, -1);      // rings -> ring
+  return x;
+}
+
+// Maak een stabiele “stamkey” op frase-niveau (woord-voor-woord)
+function toStemKey(tag) {
+  const base = asciiLower(tag).replace(/[^a-z0-9 ]+/g, ' ').replace(/\s+/g, ' ').trim();
+  if (!base) return '';
+  const words = base.split(' ').map(stemWord);
+  return words.join('-'); // 'silver rings' -> 'silver-ring'
+}
+
+// Dedupliceer met behoud van volgorde; retourneer extra context
+function dedupeByStem(tags) {
+  const seen = new Map();        // stemKey -> index van eerste voorkomens
+  const unique = [];
+  const dropped = [];
+  const duplicatesMap = {};      // stemKey -> [indices gedropt]
+
+  (Array.isArray(tags) ? tags : []).forEach((t, idx) => {
+    const key = toStemKey(t);
+    if (!key) return;
+    if (!seen.has(key)) {
+      seen.set(key, idx);
+      unique.push(t);
+    } else {
+      dropped.push(t);
+      if (!duplicatesMap[key]) duplicatesMap[key] = [];
+      duplicatesMap[key].push(idx);
+    }
+  });
+
+  return { unique, dropped, duplicatesMap };
+}
+
+module.exports = { toStemKey, dedupeByStem, _stemWord: stemWord };


### PR DESCRIPTION
- New util: functions/utils/tagUtils.js  (asciiLower, stemWord, toStemKey, dedupeByStem)
- Tests: functions/__tests__/tagUtils.dedup.test.js  (4 specs)
- Integration: generateFromDumpCore.js → dedupe + soft warning 'redundant_tag_content' + cap=13
- Docs: README fail-policy-sectie uitbreid + CHANGELOG + project_decisions_and_logs_v2.md QS-17
- All Jest suites green (14 passed, 2 skipped, 99 tests)